### PR TITLE
docs: add sample environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration for AEGIR-PRIME
+
+# API key for external service integrations
+API_KEY=
+
+# Database connection string
+DATABASE_URL=
+
+# Port for the application to listen on
+PORT=3000
+
+# Node environment
+NODE_ENV=development
+


### PR DESCRIPTION
## Summary
- add example environment configuration file

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688fc4ce12bc832e93ebd9cf4130ce00