### PR TITLE
feat: add validated env configs

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,1 +1,28 @@
-export const databaseConfig = {};
+import { env } from 'process';
+
+export interface DatabaseConfig {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  database: string;
+}
+
+function requireEnv(key: string): string {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+const config: DatabaseConfig = {
+  host: requireEnv('DB_HOST'),
+  port: Number.parseInt(requireEnv('DB_PORT'), 10),
+  username: requireEnv('DB_USER'),
+  password: requireEnv('DB_PASSWORD'),
+  database: requireEnv('DB_NAME')
+};
+
+export const databaseConfig: Readonly<DatabaseConfig> = Object.freeze(config);
+

--- a/src/config/discord.ts
+++ b/src/config/discord.ts
@@ -1,1 +1,24 @@
-export const discordConfig = {};
+import { env } from 'process';
+
+export interface DiscordConfig {
+  token: string;
+  clientId: string;
+  guildId: string;
+}
+
+function requireEnv(key: string): string {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+const config: DiscordConfig = {
+  token: requireEnv('DISCORD_TOKEN'),
+  clientId: requireEnv('DISCORD_CLIENT_ID'),
+  guildId: requireEnv('DISCORD_GUILD_ID')
+};
+
+export const discordConfig: Readonly<DiscordConfig> = Object.freeze(config);
+

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,1 +1,24 @@
-export const redisConfig = {};
+import { env } from 'process';
+
+export interface RedisConfig {
+  host: string;
+  port: number;
+  password: string;
+}
+
+function requireEnv(key: string): string {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+const config: RedisConfig = {
+  host: requireEnv('REDIS_HOST'),
+  port: Number.parseInt(requireEnv('REDIS_PORT'), 10),
+  password: requireEnv('REDIS_PASSWORD')
+};
+
+export const redisConfig: Readonly<RedisConfig> = Object.freeze(config);
+

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,1 +1,22 @@
-export const runtimeConfig = {};
+import { env } from 'process';
+
+export interface RuntimeConfig {
+  nodeEnv: string;
+  port: number;
+}
+
+function requireEnv(key: string): string {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+}
+
+const config: RuntimeConfig = {
+  nodeEnv: requireEnv('NODE_ENV'),
+  port: Number.parseInt(requireEnv('PORT'), 10)
+};
+
+export const runtimeConfig: Readonly<RuntimeConfig> = Object.freeze(config);
+


### PR DESCRIPTION
## Summary
- load Discord credentials from environment with validation
- add typed database, redis, and runtime config using env vars

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9730f40832e985d409fabb43007