### PR TITLE
feat: add stoppable health server with graceful shutdown

### DIFF
--- a/src/core/health.ts
+++ b/src/core/health.ts
@@ -1,3 +1,41 @@
+import http, { Server } from 'http';
+
 export function healthCheck(): boolean {
   return true; // Health check placeholder
+}
+
+export function startHealthServer(port = 3000): {
+  server: Server;
+  stop: () => Promise<void>;
+} {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      const ok = healthCheck();
+      res.statusCode = ok ? 200 : 500;
+      res.end(ok ? 'OK' : 'FAIL');
+    } else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+
+  server.on('error', (err) => {
+    // Log server errors to stderr
+    console.error('Health server error:', err);
+  });
+
+  server.listen(port);
+
+  const stop = () =>
+    new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+  return { server, stop };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,14 @@
+import { startHealthServer } from './health';
+
+const { stop } = startHealthServer();
+
+const shutdown = async (): Promise<void> => {
+  await stop();
+};
+
+process.once('SIGINT', shutdown);
+process.once('SIGTERM', shutdown);
+
 export * from './worker';
 export * from './container';
 export * from './logger';


### PR DESCRIPTION
## Summary
- start health server now exposes a `stop` helper and logs server errors
- main entry shuts down health server on SIGINT/SIGTERM

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd08694f0832ea82e54ff90ee38e3