### PR TITLE
feat(queue): add configurable worker factory

### DIFF
--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -1,3 +1,9 @@
-export function createContainer(): void {
-  // Container setup placeholder
+import { container, type DependencyContainer } from 'tsyringe';
+import { createWorker, type CreateWorkerOptions, type CreatedWorker } from './worker';
+
+export function createContainer(options: CreateWorkerOptions): DependencyContainer {
+  const di = container.createChildContainer();
+  di.register<CreatedWorker>('worker', { useValue: createWorker(options) });
+  return di;
 }
+

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -1,3 +1,29 @@
-export function worker(): void {
-  // Worker implementation placeholder
+import type { Processor, WorkerOptions } from 'bullmq';
+import { Worker } from 'bullmq';
+
+export interface CreateWorkerOptions {
+  queueName: string;
+  connection: WorkerOptions['connection'];
+  processor: Processor;
 }
+
+export interface CreatedWorker {
+  worker: Worker;
+  close(): Promise<void>;
+}
+
+export function createWorker({
+  queueName,
+  connection,
+  processor
+}: CreateWorkerOptions): CreatedWorker {
+  const worker = new Worker(queueName, processor, { connection });
+
+  return {
+    worker,
+    close: async (): Promise<void> => {
+      await worker.close();
+    }
+  };
+}
+

--- a/tests/unit/createWorker.test.js
+++ b/tests/unit/createWorker.test.js
@@ -1,0 +1,42 @@
+const tsnode = require('ts-node');
+tsnode.register({ transpileOnly: true, swc: false });
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+class FakeWorker {
+  constructor() {
+    this.closed = false;
+  }
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+const bullmqPath = require.resolve('bullmq');
+require.cache[bullmqPath] = {
+  id: bullmqPath,
+  filename: bullmqPath,
+  loaded: true,
+  exports: { Worker: FakeWorker }
+};
+
+const { createWorker } = require('../../src/core/worker');
+
+describe('createWorker', () => {
+  it('creates a worker with a close method', async () => {
+    const { worker, close } = createWorker({
+      queueName: 'test',
+      connection: {},
+      processor: () => {}
+    });
+
+    assert.ok(worker instanceof FakeWorker);
+
+    await close();
+
+    assert.ok(worker.closed);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add createWorker factory with runtime configuration
- register worker in DI container
- test worker creation and shutdown behavior

## Testing
- `npm test`
- `npm run build` *(fails: File 'src/modules/characters/domain/index.ts' is not a module)*

------
https://chatgpt.com/codex/tasks/task_e_688fd089de84832eb3ebb48690585dec