### PR TITLE
fix: ensure placeholder modules compile

### DIFF
--- a/src/modules/characters/application/index.ts
+++ b/src/modules/characters/application/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for characters application layer
+export {};

--- a/src/modules/characters/domain/index.ts
+++ b/src/modules/characters/domain/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for characters domain layer
+export {};

--- a/src/modules/characters/infrastructure/index.ts
+++ b/src/modules/characters/infrastructure/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for characters infrastructure layer
+export {};

--- a/src/modules/characters/interfaces/index.ts
+++ b/src/modules/characters/interfaces/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for characters interfaces layer
+export {};

--- a/src/modules/economy/application/index.ts
+++ b/src/modules/economy/application/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for economy application layer
+export {};

--- a/src/modules/economy/domain/index.ts
+++ b/src/modules/economy/domain/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for economy domain layer
+export {};

--- a/src/modules/economy/infrastructure/index.ts
+++ b/src/modules/economy/infrastructure/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for economy infrastructure layer
+export {};

--- a/src/modules/economy/interfaces/index.ts
+++ b/src/modules/economy/interfaces/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for economy interfaces layer
+export {};

--- a/src/modules/marketplace/application/index.ts
+++ b/src/modules/marketplace/application/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for marketplace application layer
+export {};

--- a/src/modules/marketplace/domain/index.ts
+++ b/src/modules/marketplace/domain/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for marketplace domain layer
+export {};

--- a/src/modules/marketplace/infrastructure/index.ts
+++ b/src/modules/marketplace/infrastructure/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for marketplace infrastructure layer
+export {};

--- a/src/modules/marketplace/interfaces/index.ts
+++ b/src/modules/marketplace/interfaces/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for marketplace interfaces layer
+export {};

--- a/src/modules/research/application/index.ts
+++ b/src/modules/research/application/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for research application layer
+export {};

--- a/src/modules/research/domain/index.ts
+++ b/src/modules/research/domain/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for research domain layer
+export {};

--- a/src/modules/research/infrastructure/index.ts
+++ b/src/modules/research/infrastructure/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for research infrastructure layer
+export {};

--- a/src/modules/research/interfaces/index.ts
+++ b/src/modules/research/interfaces/index.ts
@@ -1,1 +1,2 @@
 // Placeholder for research interfaces layer
+export {};


### PR DESCRIPTION
## Summary
- add empty exports to placeholder module indices so TypeScript treats them as modules

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd96207e4832ea5ded90fbef60851