### PR TITLE
test: add coverage for environment-aware logger

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,9 +1,9 @@
-export interface Logger {
-  info: (...args: unknown[]) => void;
-}
+import pino, { Logger as PinoLogger } from 'pino';
 
-export const logger: Logger = {
-  info: (..._args: unknown[]): void => {
-    // Logging placeholder
-  }
-};
+export type Logger = PinoLogger;
+
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export const logger: Logger = isDevelopment
+  ? pino({ transport: { target: 'pino-pretty' } })
+  : pino();

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('logger', () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('uses pino-pretty in development', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const pino = vi.fn(() => ({ info: vi.fn() }));
+    vi.doMock('pino', () => ({ default: pino }));
+
+    await import('../../src/core/logger');
+
+    expect(pino).toHaveBeenCalledTimes(1);
+    expect(pino).toHaveBeenCalledWith({
+      transport: { target: 'pino-pretty' }
+    });
+  });
+
+  it('does not use pino-pretty in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const pino = vi.fn(() => ({ info: vi.fn() }));
+    vi.doMock('pino', () => ({ default: pino }));
+
+    await import('../../src/core/logger');
+
+    expect(pino).toHaveBeenCalledTimes(1);
+    expect(pino.mock.calls[0][0]).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- integrate pino logger that enables pino-pretty when NODE_ENV=development
- add tests ensuring pino-pretty is only used in development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdbfa73b8832ebf3e306690a098ce