### PR TITLE
chore: set build output as main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "aegir-prime",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/core/index.js",
   "scripts": {
     "dev": "ts-node src/core/index.ts",
     "build": "tsc",
-    "start": "node dist/core/index.js",
-    "test": "vitest run"
+    "start": "npm run build && node .",
+    "test": "npm run build && vitest run"
   },
   "keywords": [],
   "author": "",

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+
+// Smoke test to ensure the package main entry resolves
+// Uses the main field in package.json (dist/core/index.js)
+describe('package main entry', () => {
+  it('resolves without error', async () => {
+    const mod = await import('..');
+    expect(mod).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- point package main to the compiled output and build before running
- add smoke test to ensure the package main entry resolves

## Testing
- `npm run build`
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe1902d94832e9fdb96b16dcc2772