### PR TITLE
feat: add queue adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^24.1.0",
         "pino-pretty": "^13.1.1",
+        "redis-server": "^1.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -3542,6 +3543,16 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/promise-queue": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
+      "integrity": "sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -3638,6 +3649,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/redis-server": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/redis-server/-/redis-server-1.2.2.tgz",
+      "integrity": "sha512-pOaSIeSMVFkEFIuaMtpQ3TOr3uI4sUmEHm4ofGks5vTPRseHUszxyIlC70IFjUR9qSeH8o/ARZEM8dqcJmgGJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "promise-queue": "^2.2.5"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "pino-pretty": "^13.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "redis-server": "^1.2.2"
   }
 }

--- a/src/infrastructure/queue/adapter.ts
+++ b/src/infrastructure/queue/adapter.ts
@@ -1,3 +1,58 @@
+import type { QueueOptions, JobsOptions, Job } from 'bullmq';
+import { Queue, Worker } from 'bullmq';
+
+/**
+ * Simple wrapper around BullMQ that exposes helpers for adding and
+ * processing jobs.  The adapter is purposely small – it only implements the
+ * bits of functionality that are exercised in the unit tests.
+ */
 export class QueueAdapter {
-  // TODO: Implement queue adapter logic
+  private readonly queue: Queue;
+  private worker?: Worker;
+
+  constructor(name: string, options?: QueueOptions) {
+    this.queue = new Queue(name, options);
+  }
+
+  /**
+   * Enqueue a new job into the underlying queue.
+   */
+  enqueue<T = unknown>(data: T, name = 'job', opts?: JobsOptions) {
+    return this.queue.add(name, data as any, opts);
+  }
+
+  /**
+   * Register a processor that will handle jobs for this queue.
+   * Returns the created worker so callers may listen to events.
+   */
+  process<T = unknown>(handler: (job: Job<T>) => Promise<unknown>) {
+    this.worker = new Worker<T>(this.queue.name, handler, {
+      connection: this.queue.opts.connection,
+    });
+
+    return this.worker;
+  }
+
+  /**
+   * Acknowledge a processed job by removing it from the queue.
+   */
+  async acknowledge(job: Job): Promise<void> {
+    await job.remove();
+  }
+
+  /**
+   * Helper used in tests to look up a job in the queue.
+   */
+  getJob(id: string) {
+    return this.queue.getJob(id);
+  }
+
+  /**
+   * Close the underlying queue and worker.
+   */
+  async close(): Promise<void> {
+    await this.worker?.close();
+    await this.queue.close();
+  }
 }
+

--- a/tests/unit/queue.adapter.test.ts
+++ b/tests/unit/queue.adapter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { QueueAdapter } from '../../src/infrastructure/queue/adapter';
+import RedisServer from 'redis-server';
+
+let server: any;
+const port = 6383;
+
+beforeAll(async () => {
+  server = new RedisServer(port);
+  await server.open();
+});
+
+afterAll(async () => {
+  await server.close();
+});
+
+describe('QueueAdapter', () => {
+  it('enqueues, processes, and acknowledges jobs', async () => {
+    const adapter = new QueueAdapter('test', {
+      connection: { host: '127.0.0.1', port },
+    });
+
+    const processed: unknown[] = [];
+    const worker = adapter.process(async (job) => {
+      processed.push(job.data);
+    });
+
+    const completedPromise = new Promise((resolve) =>
+      worker.once('completed', (job) => resolve(job))
+    );
+
+    await adapter.enqueue({ foo: 'bar' });
+
+    const completedJob = (await completedPromise) as any;
+    await adapter.acknowledge(completedJob);
+
+    expect(processed).toEqual([{ foo: 'bar' }]);
+    const fetched = await adapter.getJob(completedJob.id);
+    expect(fetched).toBeUndefined();
+
+    await adapter.close();
+  });
+});


### PR DESCRIPTION
## Summary
- implement BullMQ-backed queue adapter with enqueue, process, acknowledge, and shutdown helpers
- add unit test exercising job creation, processing, and removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe56e1708832e8583a344873fd111