### PR TITLE
feat: add cache adapter with ttl

### DIFF
--- a/src/infrastructure/cache/adapter.ts
+++ b/src/infrastructure/cache/adapter.ts
@@ -1,3 +1,46 @@
-export class CacheAdapter {
-  // TODO: Implement cache adapter logic
+export interface CacheEntry<T = unknown> {
+  value: T;
+  expiresAt?: number;
 }
+
+/**
+ * Lightweight in-memory cache adapter that mimics a Redis like API.  It
+ * supports storing values with optional TTL (in milliseconds) and exposing
+ * asynchronous methods for getting, setting and deleting entries.
+ */
+export class CacheAdapter {
+  private readonly store = new Map<string, CacheEntry>();
+
+  /**
+   * Store a value by key with optional TTL in milliseconds.
+   */
+  async set<T>(key: string, value: T, ttl?: number): Promise<void> {
+    const expiresAt = typeof ttl === 'number' ? Date.now() + ttl : undefined;
+    this.store.set(key, { value, expiresAt });
+  }
+
+  /**
+   * Retrieve a value by key if present and not expired.
+   */
+  async get<T>(key: string): Promise<T | undefined> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+
+    return entry.value as T;
+  }
+
+  /**
+   * Delete a value from the cache.
+   */
+  async delete(key: string): Promise<boolean> {
+    return this.store.delete(key);
+  }
+}
+

--- a/tests/unit/cache.adapter.test.ts
+++ b/tests/unit/cache.adapter.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CacheAdapter } from '../../src/infrastructure/cache/adapter';
+
+describe('CacheAdapter', () => {
+  it('stores, retrieves, and deletes values', async () => {
+    const cache = new CacheAdapter();
+    await cache.set('foo', 'bar');
+    const fetched = await cache.get('foo');
+    expect(fetched).toBe('bar');
+
+    const deleted = await cache.delete('foo');
+    expect(deleted).toBe(true);
+    const missing = await cache.get('foo');
+    expect(missing).toBeUndefined();
+  });
+
+  it('expires values after ttl', async () => {
+    const cache = new CacheAdapter();
+    await cache.set('temp', 'value', 50);
+    const before = await cache.get('temp');
+    expect(before).toBe('value');
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const after = await cache.get('temp');
+    expect(after).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add lightweight in-memory CacheAdapter with set/get/delete and TTL
- cover cache hits, deletes and TTL expiry in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68908a0734ec832eb678ea235413c116