### PR TITLE
feat(storage): implement file storage adapter

### DIFF
--- a/src/infrastructure/storage/adapter.ts
+++ b/src/infrastructure/storage/adapter.ts
@@ -1,3 +1,83 @@
-export class StorageAdapter {
-  // TODO: Implement storage adapter logic
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface StorageAdapterOptions {
+  /**
+   * Base directory where files will be stored. Defaults to
+   * `<process.cwd()>/storage` when not provided.
+   */
+  root?: string;
+  /**
+   * Public URL used for generating file links. When not provided a `file://`
+   * URL pointing to the local file is returned.
+   */
+  baseUrl?: string;
 }
+
+/**
+ * Simple storage adapter that persists files to the local filesystem. The
+ * implementation is intentionally lightweight but exposes a small API that
+ * mimics what a remote storage service (such as S3) would provide. This makes
+ * it trivial to later swap the implementation for a different backend.
+ */
+export class StorageAdapter {
+  private root: string;
+  private baseUrl: string | undefined;
+
+  constructor(options: StorageAdapterOptions = {}) {
+    this.root = options.root ?? path.resolve(process.cwd(), 'storage');
+    this.baseUrl = options.baseUrl;
+  }
+
+  private resolve(filePath: string): string {
+    return path.resolve(this.root, filePath);
+  }
+
+  /** Save a file to the configured storage location. */
+  async save(filePath: string, content: Buffer | string): Promise<void> {
+    const fullPath = this.resolve(filePath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content);
+  }
+
+  /** Retrieve a file's contents as a Buffer. */
+  async read(filePath: string): Promise<Buffer> {
+    const fullPath = this.resolve(filePath);
+    return await fs.readFile(fullPath);
+  }
+
+  /** Update a file's contents. */
+  async update(filePath: string, content: Buffer | string): Promise<void> {
+    await this.save(filePath, content);
+  }
+
+  /** Remove a file from storage. */
+  async delete(filePath: string): Promise<void> {
+    const fullPath = this.resolve(filePath);
+    await fs.unlink(fullPath);
+  }
+
+  /** Check whether a given file exists. */
+  async exists(filePath: string): Promise<boolean> {
+    const fullPath = this.resolve(filePath);
+    try {
+      await fs.access(fullPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Generate a public URL for the given file. */
+  generateUrl(filePath: string): string {
+    if (this.baseUrl) {
+      const base = this.baseUrl.replace(/\/+$/, '');
+      const normalized = filePath.split(path.sep).join('/');
+      return `${base}/${normalized}`;
+    }
+
+    return `file://${this.resolve(filePath)}`;
+  }
+}
+
+export default StorageAdapter;

--- a/tests/integration/storage.test.ts
+++ b/tests/integration/storage.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { StorageAdapter } from '../../src/infrastructure/storage/adapter';
+
+const ROOT = path.join(process.cwd(), 'tmp-storage');
+
+describe('StorageAdapter', () => {
+  let storage: StorageAdapter;
+
+  beforeEach(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+    storage = new StorageAdapter({ root: ROOT, baseUrl: 'http://localhost/files' });
+  });
+
+  afterEach(async () => {
+    await fs.rm(ROOT, { recursive: true, force: true });
+  });
+
+  it('performs basic CRUD operations and generates URLs', async () => {
+    const filePath = 'example/hello.txt';
+    const initial = 'hello world';
+    await storage.save(filePath, initial);
+
+    expect(await storage.exists(filePath)).toBe(true);
+
+    const saved = await storage.read(filePath);
+    expect(saved.toString()).toBe(initial);
+
+    await storage.update(filePath, 'updated');
+    const updated = await storage.read(filePath);
+    expect(updated.toString()).toBe('updated');
+
+    const url = storage.generateUrl(filePath);
+    expect(url).toBe('http://localhost/files/example/hello.txt');
+
+    await storage.delete(filePath);
+    expect(await storage.exists(filePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- implement filesystem-backed StorageAdapter with CRUD utilities and URL generation
- add integration tests verifying storage operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe233c9f0832e93e58f6e93d81c90