### PR TITLE
feat: implement rest transport adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.7.2",
         "bullmq": "^5.56.9",
         "discord.js": "^14.21.0",
         "pino": "^9.7.0",
@@ -1966,6 +1967,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1988,6 +1995,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2300,6 +2318,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2443,6 +2473,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -2627,6 +2666,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
@@ -2757,6 +2811,26 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2798,6 +2872,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-constants": {
@@ -3407,6 +3497,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -4024,6 +4135,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "sharp": "^0.34.3",
     "sqlite3": "^5.1.7",
     "tsyringe": "^4.10.0",
-    "typeorm": "^0.3.25"
+    "typeorm": "^0.3.25",
+    "axios": "^1.7.2"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/src/interfaces/rest/transport.ts
+++ b/src/interfaces/rest/transport.ts
@@ -1,3 +1,66 @@
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from 'axios';
+
+/**
+ * Simple REST transport adapter built on top of Axios. The adapter exposes
+ * convenience methods for common HTTP verbs and handles basic error
+ * translation and JSON response parsing.
+ */
 export class RestTransportAdapter {
-  // TODO: Implement REST transport adapter logic
+  private readonly client: AxiosInstance;
+
+  constructor(baseURL?: string, config: AxiosRequestConfig = {}) {
+    this.client = axios.create({ baseURL, ...config });
+  }
+
+  private async request<T>(
+    method: 'get' | 'post' | 'put' | 'patch' | 'delete',
+    url: string,
+    data?: unknown,
+    config: AxiosRequestConfig = {},
+  ): Promise<T> {
+    try {
+      const res: AxiosResponse<T> = await this.client.request({
+        method,
+        url,
+        data,
+        ...config,
+      });
+      return res.data;
+    } catch (err) {
+      const error = err as AxiosError;
+      const status = error.response?.status;
+      const statusText = error.response?.statusText;
+      throw new Error(
+        `HTTP ${method.toUpperCase()} ${url} failed: ${status ?? ''} ${
+          statusText ?? error.message
+        }`,
+      );
+    }
+  }
+
+  get<T>(url: string, config?: AxiosRequestConfig) {
+    return this.request<T>('get', url, undefined, config);
+  }
+
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.request<T>('post', url, data, config);
+  }
+
+  put<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.request<T>('put', url, data, config);
+  }
+
+  patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig) {
+    return this.request<T>('patch', url, data, config);
+  }
+
+  delete<T>(url: string, config?: AxiosRequestConfig) {
+    return this.request<T>('delete', url, undefined, config);
+  }
 }
+

--- a/tests/integration/rest-transport.test.ts
+++ b/tests/integration/rest-transport.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import { RestTransportAdapter } from '../../src/interfaces/rest/transport';
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+
+beforeAll(() => {
+  server = createServer((req, res) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      res.setHeader('Content-Type', 'application/json');
+      if (req.url === '/hello' && req.method === 'GET') {
+        res.writeHead(200);
+        res.end(JSON.stringify({ hello: 'world' }));
+      } else if (req.url === '/echo' && req.method === 'POST') {
+        const parsed = body ? JSON.parse(body) : {};
+        res.writeHead(200);
+        res.end(JSON.stringify({ received: parsed }));
+      } else {
+        res.writeHead(404);
+        res.end(JSON.stringify({ error: 'not found' }));
+      }
+    });
+  }).listen(0);
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('RestTransportAdapter', () => {
+  it('handles GET requests', async () => {
+    const client = new RestTransportAdapter(baseUrl);
+    const res = await client.get<{ hello: string }>('/hello');
+    expect(res).toEqual({ hello: 'world' });
+  });
+
+  it('handles POST requests with body', async () => {
+    const client = new RestTransportAdapter(baseUrl);
+    const payload = { foo: 'bar' };
+    const res = await client.post<{ received: typeof payload }>('/echo', payload);
+    expect(res).toEqual({ received: payload });
+  });
+
+  it('throws on HTTP errors', async () => {
+    const client = new RestTransportAdapter(baseUrl);
+    await expect(client.get('/missing')).rejects.toThrow(/404/);
+  });
+});


### PR DESCRIPTION
## Summary
- implement RestTransportAdapter with axios for HTTP requests, error handling, and JSON parsing
- add axios dependency
- test RestTransportAdapter via integration tests for GET/POST and error scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68908e1b14d8832e897cb56c47349dca