### PR TITLE
feat(discord): add transport adapter

### DIFF
--- a/src/interfaces/discord/transport.ts
+++ b/src/interfaces/discord/transport.ts
@@ -1,3 +1,63 @@
+import {
+  Client,
+  GatewayIntentBits,
+  type ClientOptions,
+} from 'discord.js';
+
+/**
+ * Minimal wrapper around the `discord.js` client exposing a small,
+ * promise based API used by the project.  The adapter is responsible for
+ * connecting to Discord, sending messages to channels and allowing consumers
+ * to listen to client events.
+ */
 export class DiscordTransportAdapter {
-  // TODO: Implement Discord transport adapter logic
+  private client?: Client;
+
+  /**
+   * Create and login the Discord client.  Consumers may optionally pass
+   * additional {@link ClientOptions}.  A basic set of intents is provided by
+   * default to allow the bot to operate in guild text channels.
+   */
+  async init(token: string, options: Partial<ClientOptions> = {}): Promise<void> {
+    const clientOptions: ClientOptions = {
+      ...options,
+      intents:
+        options.intents ?? [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+    };
+
+    this.client = new Client(clientOptions);
+
+    await this.client.login(token);
+  }
+
+  private getClient(): Client {
+    if (!this.client) {
+      throw new Error('Discord client not initialized');
+    }
+
+    return this.client;
+  }
+
+  /**
+   * Send a message to the specified channel.  The channel must be text based
+   * otherwise an error is thrown.
+   */
+  async sendMessage(channelId: string, content: string): Promise<void> {
+    const client = this.getClient();
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) {
+      throw new Error('Channel not found or not text based');
+    }
+
+    await (channel as any).send(content);
+  }
+
+  /**
+   * Register an event listener on the underlying Discord client.
+   */
+  on(event: string, listener: (...args: any[]) => void): void {
+    const client = this.getClient();
+    client.on(event, listener);
+  }
 }
+

--- a/tests/unit/discord.transport.test.ts
+++ b/tests/unit/discord.transport.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock discord.js before importing the adapter so that it uses the mock
+const login = vi.fn();
+const on = vi.fn();
+const fetch = vi.fn();
+
+const ClientMock = vi.fn(() => ({
+  login,
+  on,
+  channels: { fetch },
+}));
+
+vi.mock('discord.js', () => ({
+  Client: ClientMock,
+  GatewayIntentBits: { Guilds: 1, GuildMessages: 2 },
+}));
+
+let DiscordTransportAdapter: any;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  DiscordTransportAdapter = (await import('../../src/interfaces/discord/transport')).DiscordTransportAdapter;
+});
+
+describe('DiscordTransportAdapter', () => {
+  it('initializes the client and logs in', async () => {
+    const adapter = new DiscordTransportAdapter();
+    await adapter.init('token');
+
+    expect(ClientMock).toHaveBeenCalledWith({ intents: [1, 2] });
+    expect(login).toHaveBeenCalledWith('token');
+  });
+
+  it('sends messages to channels', async () => {
+    const adapter = new DiscordTransportAdapter();
+    await adapter.init('token');
+
+    const send = vi.fn();
+    fetch.mockResolvedValue({ send, isTextBased: () => true });
+
+    await adapter.sendMessage('123', 'hello');
+
+    expect(fetch).toHaveBeenCalledWith('123');
+    expect(send).toHaveBeenCalledWith('hello');
+  });
+
+  it('registers event listeners', async () => {
+    const adapter = new DiscordTransportAdapter();
+    await adapter.init('token');
+
+    const handler = vi.fn();
+    adapter.on('ready', handler);
+
+    expect(on).toHaveBeenCalledWith('ready', handler);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Discord transport adapter wrapping discord.js client
- test Discord transport interactions with mocked discord.js

## Testing
- `npm test` *(fails: spawn redis-server ENOENT)*
- `npx vitest run tests/unit/discord.transport.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68908fb09cb0832eabf97eb7a314b21f