### PR TITLE
feat: add initial Prisma setup

### DIFF
--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,19 @@
+# Prisma Setup
+
+This directory contains the Prisma schema and database migrations.
+
+## Running Migrations
+
+1. Ensure the `DATABASE_URL` environment variable is set in your `.env` file.
+2. Apply migrations in development:
+   ```bash
+   npx prisma migrate dev
+   ```
+3. For production, use:
+   ```bash
+   npx prisma migrate deploy
+   ```
+4. Generate the Prisma client after running migrations:
+   ```bash
+   npx prisma generate
+   ```

--- a/prisma/migrations/000_init.sql
+++ b/prisma/migrations/000_init.sql
@@ -1,0 +1,22 @@
+-- Baseline migration for initial models
+
+CREATE TABLE "Character" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL
+);
+
+CREATE TABLE "Wallet" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "balance" INTEGER NOT NULL
+);
+
+CREATE TABLE "Listing" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "title" TEXT NOT NULL,
+  "price" INTEGER NOT NULL
+);
+
+CREATE TABLE "Technology" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,34 @@
+// Prisma schema for AEGIR-PRIME
+
+// Generator for Prisma Client
+// (run `npx prisma generate` to generate the client)
+generator client {
+  provider = "prisma-client-js"
+}
+
+// SQLite datasource (update DATABASE_URL if needed)
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Character {
+  id   String @id @default(uuid())
+  name String
+}
+
+model Wallet {
+  id      String @id @default(uuid())
+  balance Int
+}
+
+model Listing {
+  id    String @id @default(uuid())
+  title String
+  price Int
+}
+
+model Technology {
+  id   String @id @default(uuid())
+  name String
+}


### PR DESCRIPTION
## Summary
- set up Prisma schema for core modules
- add baseline SQL migration
- document migration workflow

## Testing
- `npm test` *(fails: spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6890aa1ca6b0832e9dea28c84b6542fc