### PR TITLE
feat: add domain and application layers

### DIFF
--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -43,24 +43,28 @@ export function createContainer(): DependencyContainer {
     useFactory: (c) => new Worker(c.resolve('logger'))
   });
 
-  child.register<CharacterRepository>(CHARACTER_REPOSITORY, {
-    useClass: InMemoryCharacterRepository
-  });
+  child.registerSingleton<CharacterRepository>(
+    CHARACTER_REPOSITORY,
+    InMemoryCharacterRepository
+  );
   child.register(CharacterService, { useClass: CharacterService });
 
-  child.register<WalletRepository>(WALLET_REPOSITORY, {
-    useClass: InMemoryWalletRepository
-  });
+  child.registerSingleton<WalletRepository>(
+    WALLET_REPOSITORY,
+    InMemoryWalletRepository
+  );
   child.register(EconomyService, { useClass: EconomyService });
 
-  child.register<ListingRepository>(LISTING_REPOSITORY, {
-    useClass: InMemoryListingRepository
-  });
+  child.registerSingleton<ListingRepository>(
+    LISTING_REPOSITORY,
+    InMemoryListingRepository
+  );
   child.register(MarketplaceService, { useClass: MarketplaceService });
 
-  child.register<ResearchRepository>(RESEARCH_REPOSITORY, {
-    useClass: InMemoryResearchRepository
-  });
+  child.registerSingleton<ResearchRepository>(
+    RESEARCH_REPOSITORY,
+    InMemoryResearchRepository
+  );
   child.register(ResearchService, { useClass: ResearchService });
 
   child.register<DatabaseClient>(DATABASE_CLIENT, { useClass: DatabaseAdapter });

--- a/src/infrastructure/db/adapter.ts
+++ b/src/infrastructure/db/adapter.ts
@@ -40,7 +40,7 @@ export class DatabaseAdapter implements DatabaseClient {
   /** Run the provided callback inside a transaction. */
   async transaction<T>(fn: (prisma: PrismaClient) => Promise<T>): Promise<T> {
     await this.initialize();
-    return this.client.$transaction(fn);
+    return this.client.$transaction(fn as any) as unknown as T;
   }
 
   /** Disconnect the underlying Prisma client. */

--- a/src/modules/characters/application/index.ts
+++ b/src/modules/characters/application/index.ts
@@ -1,18 +1,2 @@
-import { inject, injectable } from 'tsyringe';
-import { Character } from '../domain';
-import { CHARACTER_REPOSITORY, CharacterRepository } from '../interfaces';
-
-@injectable()
-export class CharacterService {
-  constructor(
-    @inject(CHARACTER_REPOSITORY) private readonly repo: CharacterRepository
-  ) {}
-
-  create(character: Character): void {
-    this.repo.add(character);
-  }
-
-  get(id: string): Character | undefined {
-    return this.repo.findById(id);
-  }
-}
+export * from './use-cases';
+export * from './orchestrators';

--- a/src/modules/characters/application/orchestrators/character.service.ts
+++ b/src/modules/characters/application/orchestrators/character.service.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from 'tsyringe';
+import { CreateCharacter, GetCharacter } from '../use-cases';
+import { Character } from '../../domain';
+
+@injectable()
+export class CharacterService {
+  constructor(
+    @inject(CreateCharacter) private readonly createCharacter: CreateCharacter,
+    @inject(GetCharacter) private readonly getCharacter: GetCharacter
+  ) {}
+
+  create(character: Character): void {
+    this.createCharacter.execute(character);
+  }
+
+  get(id: string): Character | undefined {
+    return this.getCharacter.execute(id);
+  }
+}

--- a/src/modules/characters/application/orchestrators/index.ts
+++ b/src/modules/characters/application/orchestrators/index.ts
@@ -1,0 +1,1 @@
+export * from './character.service';

--- a/src/modules/characters/application/use-cases/create-character.ts
+++ b/src/modules/characters/application/use-cases/create-character.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Character } from '../../domain';
+import {
+  CHARACTER_REPOSITORY,
+  CharacterRepository,
+} from '../../interfaces';
+
+@injectable()
+export class CreateCharacter {
+  constructor(
+    @inject(CHARACTER_REPOSITORY)
+    private readonly repo: CharacterRepository
+  ) {}
+
+  execute(character: Character): void {
+    this.repo.add(character);
+  }
+}

--- a/src/modules/characters/application/use-cases/get-character.ts
+++ b/src/modules/characters/application/use-cases/get-character.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Character } from '../../domain';
+import {
+  CHARACTER_REPOSITORY,
+  CharacterRepository,
+} from '../../interfaces';
+
+@injectable()
+export class GetCharacter {
+  constructor(
+    @inject(CHARACTER_REPOSITORY)
+    private readonly repo: CharacterRepository
+  ) {}
+
+  execute(id: string): Character | undefined {
+    return this.repo.findById(id);
+  }
+}

--- a/src/modules/characters/application/use-cases/index.ts
+++ b/src/modules/characters/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './create-character';
+export * from './get-character';

--- a/src/modules/characters/domain/entities/character.ts
+++ b/src/modules/characters/domain/entities/character.ts
@@ -1,0 +1,5 @@
+import { CharacterName } from '../value-objects';
+
+export class Character {
+  constructor(public readonly id: string, public name: CharacterName) {}
+}

--- a/src/modules/characters/domain/entities/index.ts
+++ b/src/modules/characters/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './character';

--- a/src/modules/characters/domain/events/character-created.event.ts
+++ b/src/modules/characters/domain/events/character-created.event.ts
@@ -1,0 +1,5 @@
+import { Character } from '../entities';
+
+export class CharacterCreatedEvent {
+  constructor(public readonly character: Character) {}
+}

--- a/src/modules/characters/domain/events/index.ts
+++ b/src/modules/characters/domain/events/index.ts
@@ -1,0 +1,1 @@
+export * from './character-created.event';

--- a/src/modules/characters/domain/index.ts
+++ b/src/modules/characters/domain/index.ts
@@ -1,4 +1,3 @@
-export interface Character {
-  id: string;
-  name: string;
-}
+export * from './entities';
+export * from './value-objects';
+export * from './events';

--- a/src/modules/characters/domain/value-objects/character-name.ts
+++ b/src/modules/characters/domain/value-objects/character-name.ts
@@ -1,0 +1,9 @@
+export class CharacterName {
+  constructor(private readonly _value: string) {
+    if (!_value) throw new Error('Character name cannot be empty');
+  }
+
+  get value(): string {
+    return this._value;
+  }
+}

--- a/src/modules/characters/domain/value-objects/index.ts
+++ b/src/modules/characters/domain/value-objects/index.ts
@@ -1,0 +1,1 @@
+export * from './character-name';

--- a/src/modules/economy/application/index.ts
+++ b/src/modules/economy/application/index.ts
@@ -1,21 +1,2 @@
-import { inject, injectable } from 'tsyringe';
-import { Wallet } from '../domain';
-import { WALLET_REPOSITORY, WalletRepository } from '../interfaces';
-
-@injectable()
-export class EconomyService {
-  constructor(
-    @inject(WALLET_REPOSITORY) private readonly repo: WalletRepository
-  ) {}
-
-  getBalance(id: string): number {
-    const wallet = this.repo.get(id);
-    return wallet ? wallet.balance : 0;
-  }
-
-  deposit(id: string, amount: number): void {
-    const wallet = this.repo.get(id) || { id, balance: 0 };
-    wallet.balance += amount;
-    this.repo.save(wallet);
-  }
-}
+export * from './use-cases';
+export * from './orchestrators';

--- a/src/modules/economy/application/orchestrators/economy.service.ts
+++ b/src/modules/economy/application/orchestrators/economy.service.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { DepositFunds, GetBalance } from '../use-cases';
+
+@injectable()
+export class EconomyService {
+  constructor(
+    @inject(DepositFunds) private readonly depositFunds: DepositFunds,
+    @inject(GetBalance) private readonly getBalanceUseCase: GetBalance
+  ) {}
+
+  getBalance(id: string): number {
+    return this.getBalanceUseCase.execute(id);
+  }
+
+  deposit(id: string, amount: number): void {
+    this.depositFunds.execute(id, amount);
+  }
+}

--- a/src/modules/economy/application/orchestrators/index.ts
+++ b/src/modules/economy/application/orchestrators/index.ts
@@ -1,0 +1,1 @@
+export * from './economy.service';

--- a/src/modules/economy/application/use-cases/deposit-funds.ts
+++ b/src/modules/economy/application/use-cases/deposit-funds.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Wallet, Currency } from '../../domain';
+import { WALLET_REPOSITORY, WalletRepository } from '../../interfaces';
+
+@injectable()
+export class DepositFunds {
+  constructor(
+    @inject(WALLET_REPOSITORY)
+    private readonly repo: WalletRepository
+  ) {}
+
+  execute(id: string, amount: number): Wallet {
+    const wallet = this.repo.get(id) ?? new Wallet(id, new Currency(0));
+    wallet.deposit(new Currency(amount));
+    this.repo.save(wallet);
+    return wallet;
+  }
+}

--- a/src/modules/economy/application/use-cases/get-balance.ts
+++ b/src/modules/economy/application/use-cases/get-balance.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from 'tsyringe';
+import { WALLET_REPOSITORY, WalletRepository } from '../../interfaces';
+
+@injectable()
+export class GetBalance {
+  constructor(
+    @inject(WALLET_REPOSITORY)
+    private readonly repo: WalletRepository
+  ) {}
+
+  execute(id: string): number {
+    const wallet = this.repo.get(id);
+    return wallet ? wallet.balance.value : 0;
+  }
+}

--- a/src/modules/economy/application/use-cases/index.ts
+++ b/src/modules/economy/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './deposit-funds';
+export * from './get-balance';

--- a/src/modules/economy/domain/entities/index.ts
+++ b/src/modules/economy/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './wallet';

--- a/src/modules/economy/domain/entities/wallet.ts
+++ b/src/modules/economy/domain/entities/wallet.ts
@@ -1,0 +1,9 @@
+import { Currency } from '../value-objects';
+
+export class Wallet {
+  constructor(public readonly id: string, public balance: Currency) {}
+
+  deposit(amount: Currency): void {
+    this.balance = new Currency(this.balance.value + amount.value);
+  }
+}

--- a/src/modules/economy/domain/events/funds-deposited.event.ts
+++ b/src/modules/economy/domain/events/funds-deposited.event.ts
@@ -1,0 +1,6 @@
+import { Wallet } from '../entities';
+import { Currency } from '../value-objects';
+
+export class FundsDepositedEvent {
+  constructor(public readonly wallet: Wallet, public readonly amount: Currency) {}
+}

--- a/src/modules/economy/domain/events/index.ts
+++ b/src/modules/economy/domain/events/index.ts
@@ -1,0 +1,1 @@
+export * from './funds-deposited.event';

--- a/src/modules/economy/domain/index.ts
+++ b/src/modules/economy/domain/index.ts
@@ -1,4 +1,3 @@
-export interface Wallet {
-  id: string;
-  balance: number;
-}
+export * from './entities';
+export * from './value-objects';
+export * from './events';

--- a/src/modules/economy/domain/value-objects/currency.ts
+++ b/src/modules/economy/domain/value-objects/currency.ts
@@ -1,0 +1,9 @@
+export class Currency {
+  constructor(private readonly _value: number) {
+    if (_value < 0) throw new Error('Currency cannot be negative');
+  }
+
+  get value(): number {
+    return this._value;
+  }
+}

--- a/src/modules/economy/domain/value-objects/index.ts
+++ b/src/modules/economy/domain/value-objects/index.ts
@@ -1,0 +1,1 @@
+export * from './currency';

--- a/src/modules/marketplace/application/index.ts
+++ b/src/modules/marketplace/application/index.ts
@@ -1,18 +1,2 @@
-import { inject, injectable } from 'tsyringe';
-import { Listing } from '../domain';
-import { LISTING_REPOSITORY, ListingRepository } from '../interfaces';
-
-@injectable()
-export class MarketplaceService {
-  constructor(
-    @inject(LISTING_REPOSITORY) private readonly repo: ListingRepository
-  ) {}
-
-  listItem(listing: Listing): void {
-    this.repo.add(listing);
-  }
-
-  getListing(id: string): Listing | undefined {
-    return this.repo.find(id);
-  }
-}
+export * from './use-cases';
+export * from './orchestrators';

--- a/src/modules/marketplace/application/orchestrators/index.ts
+++ b/src/modules/marketplace/application/orchestrators/index.ts
@@ -1,0 +1,1 @@
+export * from './marketplace.service';

--- a/src/modules/marketplace/application/orchestrators/marketplace.service.ts
+++ b/src/modules/marketplace/application/orchestrators/marketplace.service.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from 'tsyringe';
+import { GetListing, ListItem } from '../use-cases';
+import { Listing } from '../../domain';
+
+@injectable()
+export class MarketplaceService {
+  constructor(
+    @inject(ListItem) private readonly listItemUseCase: ListItem,
+    @inject(GetListing) private readonly getListingUseCase: GetListing
+  ) {}
+
+  listItem(listing: Listing): void {
+    this.listItemUseCase.execute(listing);
+  }
+
+  getListing(id: string): Listing | undefined {
+    return this.getListingUseCase.execute(id);
+  }
+}

--- a/src/modules/marketplace/application/use-cases/get-listing.ts
+++ b/src/modules/marketplace/application/use-cases/get-listing.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Listing } from '../../domain';
+import {
+  LISTING_REPOSITORY,
+  ListingRepository,
+} from '../../interfaces';
+
+@injectable()
+export class GetListing {
+  constructor(
+    @inject(LISTING_REPOSITORY)
+    private readonly repo: ListingRepository
+  ) {}
+
+  execute(id: string): Listing | undefined {
+    return this.repo.find(id);
+  }
+}

--- a/src/modules/marketplace/application/use-cases/index.ts
+++ b/src/modules/marketplace/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './list-item';
+export * from './get-listing';

--- a/src/modules/marketplace/application/use-cases/list-item.ts
+++ b/src/modules/marketplace/application/use-cases/list-item.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Listing } from '../../domain';
+import {
+  LISTING_REPOSITORY,
+  ListingRepository,
+} from '../../interfaces';
+
+@injectable()
+export class ListItem {
+  constructor(
+    @inject(LISTING_REPOSITORY)
+    private readonly repo: ListingRepository
+  ) {}
+
+  execute(listing: Listing): void {
+    this.repo.add(listing);
+  }
+}

--- a/src/modules/marketplace/domain/entities/index.ts
+++ b/src/modules/marketplace/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './listing';

--- a/src/modules/marketplace/domain/entities/listing.ts
+++ b/src/modules/marketplace/domain/entities/listing.ts
@@ -1,0 +1,9 @@
+import { Price } from '../value-objects';
+
+export class Listing {
+  constructor(
+    public readonly id: string,
+    public title: string,
+    public price: Price
+  ) {}
+}

--- a/src/modules/marketplace/domain/events/index.ts
+++ b/src/modules/marketplace/domain/events/index.ts
@@ -1,0 +1,1 @@
+export * from './listing-created.event';

--- a/src/modules/marketplace/domain/events/listing-created.event.ts
+++ b/src/modules/marketplace/domain/events/listing-created.event.ts
@@ -1,0 +1,5 @@
+import { Listing } from '../entities';
+
+export class ListingCreatedEvent {
+  constructor(public readonly listing: Listing) {}
+}

--- a/src/modules/marketplace/domain/index.ts
+++ b/src/modules/marketplace/domain/index.ts
@@ -1,5 +1,3 @@
-export interface Listing {
-  id: string;
-  title: string;
-  price: number;
-}
+export * from './entities';
+export * from './value-objects';
+export * from './events';

--- a/src/modules/marketplace/domain/value-objects/index.ts
+++ b/src/modules/marketplace/domain/value-objects/index.ts
@@ -1,0 +1,1 @@
+export * from './price';

--- a/src/modules/marketplace/domain/value-objects/price.ts
+++ b/src/modules/marketplace/domain/value-objects/price.ts
@@ -1,0 +1,9 @@
+export class Price {
+  constructor(private readonly _value: number) {
+    if (_value < 0) throw new Error('Price cannot be negative');
+  }
+
+  get value(): number {
+    return this._value;
+  }
+}

--- a/src/modules/research/application/index.ts
+++ b/src/modules/research/application/index.ts
@@ -1,18 +1,2 @@
-import { inject, injectable } from 'tsyringe';
-import { Technology } from '../domain';
-import { RESEARCH_REPOSITORY, ResearchRepository } from '../interfaces';
-
-@injectable()
-export class ResearchService {
-  constructor(
-    @inject(RESEARCH_REPOSITORY) private readonly repo: ResearchRepository
-  ) {}
-
-  addTechnology(tech: Technology): void {
-    this.repo.add(tech);
-  }
-
-  getTechnology(id: string): Technology | undefined {
-    return this.repo.get(id);
-  }
-}
+export * from './use-cases';
+export * from './orchestrators';

--- a/src/modules/research/application/orchestrators/index.ts
+++ b/src/modules/research/application/orchestrators/index.ts
@@ -1,0 +1,1 @@
+export * from './research.service';

--- a/src/modules/research/application/orchestrators/research.service.ts
+++ b/src/modules/research/application/orchestrators/research.service.ts
@@ -1,0 +1,21 @@
+import { inject, injectable } from 'tsyringe';
+import { AddTechnology, GetTechnology } from '../use-cases';
+import { Technology } from '../../domain';
+
+@injectable()
+export class ResearchService {
+  constructor(
+    @inject(AddTechnology)
+    private readonly addTechnologyUseCase: AddTechnology,
+    @inject(GetTechnology)
+    private readonly getTechnologyUseCase: GetTechnology
+  ) {}
+
+  addTechnology(tech: Technology): void {
+    this.addTechnologyUseCase.execute(tech);
+  }
+
+  getTechnology(id: string): Technology | undefined {
+    return this.getTechnologyUseCase.execute(id);
+  }
+}

--- a/src/modules/research/application/use-cases/add-technology.ts
+++ b/src/modules/research/application/use-cases/add-technology.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Technology } from '../../domain';
+import {
+  RESEARCH_REPOSITORY,
+  ResearchRepository,
+} from '../../interfaces';
+
+@injectable()
+export class AddTechnology {
+  constructor(
+    @inject(RESEARCH_REPOSITORY)
+    private readonly repo: ResearchRepository
+  ) {}
+
+  execute(tech: Technology): void {
+    this.repo.add(tech);
+  }
+}

--- a/src/modules/research/application/use-cases/get-technology.ts
+++ b/src/modules/research/application/use-cases/get-technology.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+import { Technology } from '../../domain';
+import {
+  RESEARCH_REPOSITORY,
+  ResearchRepository,
+} from '../../interfaces';
+
+@injectable()
+export class GetTechnology {
+  constructor(
+    @inject(RESEARCH_REPOSITORY)
+    private readonly repo: ResearchRepository
+  ) {}
+
+  execute(id: string): Technology | undefined {
+    return this.repo.get(id);
+  }
+}

--- a/src/modules/research/application/use-cases/index.ts
+++ b/src/modules/research/application/use-cases/index.ts
@@ -1,0 +1,2 @@
+export * from './add-technology';
+export * from './get-technology';

--- a/src/modules/research/domain/entities/index.ts
+++ b/src/modules/research/domain/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './technology';

--- a/src/modules/research/domain/entities/technology.ts
+++ b/src/modules/research/domain/entities/technology.ts
@@ -1,0 +1,5 @@
+import { TechnologyName } from '../value-objects';
+
+export class Technology {
+  constructor(public readonly id: string, public name: TechnologyName) {}
+}

--- a/src/modules/research/domain/events/index.ts
+++ b/src/modules/research/domain/events/index.ts
@@ -1,0 +1,1 @@
+export * from './technology-added.event';

--- a/src/modules/research/domain/events/technology-added.event.ts
+++ b/src/modules/research/domain/events/technology-added.event.ts
@@ -1,0 +1,5 @@
+import { Technology } from '../entities';
+
+export class TechnologyAddedEvent {
+  constructor(public readonly technology: Technology) {}
+}

--- a/src/modules/research/domain/index.ts
+++ b/src/modules/research/domain/index.ts
@@ -1,4 +1,3 @@
-export interface Technology {
-  id: string;
-  name: string;
-}
+export * from './entities';
+export * from './value-objects';
+export * from './events';

--- a/src/modules/research/domain/value-objects/index.ts
+++ b/src/modules/research/domain/value-objects/index.ts
@@ -1,0 +1,1 @@
+export * from './technology-name';

--- a/src/modules/research/domain/value-objects/technology-name.ts
+++ b/src/modules/research/domain/value-objects/technology-name.ts
@@ -1,0 +1,9 @@
+export class TechnologyName {
+  constructor(private readonly _value: string) {
+    if (!_value) throw new Error('Technology name cannot be empty');
+  }
+
+  get value(): string {
+    return this._value;
+  }
+}

--- a/tests/integration/modules.integration.test.ts
+++ b/tests/integration/modules.integration.test.ts
@@ -1,29 +1,43 @@
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
 import { createContainer } from '../../src/core/container';
-import { CharacterService } from '../../src/modules/characters';
+import {
+  CharacterService,
+  Character,
+  CharacterName,
+} from '../../src/modules/characters';
 import { EconomyService } from '../../src/modules/economy';
-import { MarketplaceService } from '../../src/modules/marketplace';
-import { ResearchService } from '../../src/modules/research';
+import {
+  MarketplaceService,
+  Listing,
+  Price,
+} from '../../src/modules/marketplace';
+import {
+  ResearchService,
+  Technology,
+  TechnologyName,
+} from '../../src/modules/research';
 
 describe('module integration', () => {
   it('resolves services from container', () => {
     const c = createContainer();
 
     const characterService = c.resolve(CharacterService);
-    characterService.create({ id: '1', name: 'Alice' });
-    expect(characterService.get('1')?.name).toBe('Alice');
+    characterService.create(new Character('1', new CharacterName('Alice')));
+    expect(characterService.get('1')?.name.value).toBe('Alice');
 
     const economyService = c.resolve(EconomyService);
     economyService.deposit('w1', 10);
     expect(economyService.getBalance('w1')).toBe(10);
 
     const marketplaceService = c.resolve(MarketplaceService);
-    marketplaceService.listItem({ id: 'l1', title: 'Sword', price: 5 });
-    expect(marketplaceService.getListing('l1')?.price).toBe(5);
+    marketplaceService.listItem(new Listing('l1', 'Sword', new Price(5)));
+    expect(marketplaceService.getListing('l1')?.price.value).toBe(5);
 
     const researchService = c.resolve(ResearchService);
-    researchService.addTechnology({ id: 't1', name: 'AI' });
-    expect(researchService.getTechnology('t1')?.name).toBe('AI');
+    researchService.addTechnology(
+      new Technology('t1', new TechnologyName('AI'))
+    );
+    expect(researchService.getTechnology('t1')?.name.value).toBe('AI');
   });
 });

--- a/tests/unit/characters.service.test.ts
+++ b/tests/unit/characters.service.test.ts
@@ -1,12 +1,22 @@
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
-import { CharacterService, InMemoryCharacterRepository } from '../../src/modules/characters';
+import {
+  CharacterService,
+  InMemoryCharacterRepository,
+  CreateCharacter,
+  GetCharacter,
+  Character,
+  CharacterName,
+} from '../../src/modules/characters';
 
 describe('CharacterService', () => {
   it('creates and retrieves characters', () => {
     const repo = new InMemoryCharacterRepository();
-    const service = new CharacterService(repo);
-    const character = { id: '1', name: 'Alice' };
+    const service = new CharacterService(
+      new CreateCharacter(repo),
+      new GetCharacter(repo)
+    );
+    const character = new Character('1', new CharacterName('Alice'));
     service.create(character);
     expect(service.get('1')).toEqual(character);
   });

--- a/tests/unit/economy.service.test.ts
+++ b/tests/unit/economy.service.test.ts
@@ -1,11 +1,19 @@
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
-import { EconomyService, InMemoryWalletRepository } from '../../src/modules/economy';
+import {
+  EconomyService,
+  InMemoryWalletRepository,
+  DepositFunds,
+  GetBalance,
+} from '../../src/modules/economy';
 
 describe('EconomyService', () => {
   it('deposits funds and retrieves balance', () => {
     const repo = new InMemoryWalletRepository();
-    const service = new EconomyService(repo);
+    const service = new EconomyService(
+      new DepositFunds(repo),
+      new GetBalance(repo)
+    );
     service.deposit('wallet1', 100);
     expect(service.getBalance('wallet1')).toBe(100);
   });

--- a/tests/unit/marketplace.service.test.ts
+++ b/tests/unit/marketplace.service.test.ts
@@ -1,12 +1,22 @@
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
-import { MarketplaceService, InMemoryListingRepository } from '../../src/modules/marketplace';
+import {
+  MarketplaceService,
+  InMemoryListingRepository,
+  ListItem,
+  GetListing,
+  Listing,
+  Price,
+} from '../../src/modules/marketplace';
 
 describe('MarketplaceService', () => {
   it('lists and retrieves items', () => {
     const repo = new InMemoryListingRepository();
-    const service = new MarketplaceService(repo);
-    const listing = { id: '1', title: 'Sword', price: 50 };
+    const service = new MarketplaceService(
+      new ListItem(repo),
+      new GetListing(repo)
+    );
+    const listing = new Listing('1', 'Sword', new Price(50));
     service.listItem(listing);
     expect(service.getListing('1')).toEqual(listing);
   });

--- a/tests/unit/research.service.test.ts
+++ b/tests/unit/research.service.test.ts
@@ -1,12 +1,22 @@
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
-import { ResearchService, InMemoryResearchRepository } from '../../src/modules/research';
+import {
+  ResearchService,
+  InMemoryResearchRepository,
+  AddTechnology,
+  GetTechnology,
+  Technology,
+  TechnologyName,
+} from '../../src/modules/research';
 
 describe('ResearchService', () => {
   it('adds and retrieves technologies', () => {
     const repo = new InMemoryResearchRepository();
-    const service = new ResearchService(repo);
-    const tech = { id: '1', name: 'AI' };
+    const service = new ResearchService(
+      new AddTechnology(repo),
+      new GetTechnology(repo)
+    );
+    const tech = new Technology('1', new TechnologyName('AI'));
     service.addTechnology(tech);
     expect(service.getTechnology('1')).toEqual(tech);
   });


### PR DESCRIPTION
## Summary
- scaffold domain entities, value objects, and events for each module
- add use cases with coordinating services
- register module repositories as singletons

## Testing
- `npm test` *(fails: redis-server ENOENT)*
- `npx vitest run tests/integration/modules.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890b1064d70832e90cbd59e49e3ab1e