### PR TITLE
feat(discord): add guild command registration and event gateway

### DIFF
--- a/src/interfaces/discord/eventGateway.ts
+++ b/src/interfaces/discord/eventGateway.ts
@@ -1,0 +1,19 @@
+import { Client, Interaction, Events } from 'discord.js';
+
+export interface EventGatewayOptions {
+  onReady?: (client: Client) => void;
+  onInteraction?: (interaction: Interaction) => void | Promise<void>;
+}
+
+export function eventGateway(
+  client: Client,
+  options: EventGatewayOptions = {},
+): void {
+  if (options.onReady) {
+    client.once(Events.ClientReady, () => options.onReady!(client));
+  }
+
+  if (options.onInteraction) {
+    client.on(Events.InteractionCreate, options.onInteraction);
+  }
+}

--- a/src/interfaces/discord/guards/index.ts
+++ b/src/interfaces/discord/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './role';

--- a/src/interfaces/discord/guards/role.ts
+++ b/src/interfaces/discord/guards/role.ts
@@ -1,0 +1,11 @@
+import { GuildMember } from 'discord.js';
+
+export function hasRole(member: GuildMember, roleId: string): boolean {
+  return member.roles.cache.has(roleId);
+}
+
+export function requireRole(member: GuildMember, roleId: string): void {
+  if (!hasRole(member, roleId)) {
+    throw new Error(`Missing required role: ${roleId}`);
+  }
+}

--- a/src/interfaces/discord/registerGuildCommands.ts
+++ b/src/interfaces/discord/registerGuildCommands.ts
@@ -1,0 +1,10 @@
+import { Client, ApplicationCommandDataResolvable } from 'discord.js';
+
+export async function registerGuildCommands(
+  client: Client,
+  guildId: string,
+  commands: ApplicationCommandDataResolvable[],
+): Promise<void> {
+  const guild = await client.guilds.fetch(guildId);
+  await guild.commands.set(commands);
+}

--- a/src/interfaces/discord/transport.ts
+++ b/src/interfaces/discord/transport.ts
@@ -2,7 +2,10 @@ import {
   Client,
   GatewayIntentBits,
   type ClientOptions,
+  type ApplicationCommandDataResolvable,
 } from 'discord.js';
+import { eventGateway, type EventGatewayOptions } from './eventGateway';
+import { registerGuildCommands } from './registerGuildCommands';
 
 /**
  * Minimal wrapper around the `discord.js` client exposing a small,
@@ -59,5 +62,29 @@ export class DiscordTransportAdapter {
     const client = this.getClient();
     client.on(event, listener);
   }
+
+  /**
+   * Register commonly used Discord gateway events like `ready` and
+   * `interactionCreate`.
+   */
+  useEventGateway(options: EventGatewayOptions): void {
+    const client = this.getClient();
+    eventGateway(client, options);
+  }
+
+  /**
+   * Register slash commands for the specified guild.
+   */
+  async registerGuildCommands(
+    guildId: string,
+    commands: ApplicationCommandDataResolvable[],
+  ): Promise<void> {
+    const client = this.getClient();
+    await registerGuildCommands(client, guildId, commands);
+  }
 }
+
+export { eventGateway, registerGuildCommands };
+export type { EventGatewayOptions };
+export * as guards from './guards';
 


### PR DESCRIPTION
## Summary
- add helper for registering guild slash commands
- provide gateway utility to hook ready and interaction events
- introduce role-based guard utilities and expose through transport

## Testing
- `npm test` *(fails: src/infrastructure/db/adapter.ts type error)*

------
https://chatgpt.com/codex/tasks/task_e_6890b5222f5c832e9e53834d97dbfc58