### PR TITLE
feat: add express server transport

### DIFF
--- a/tests/integration/rest-transport.test.ts
+++ b/tests/integration/rest-transport.test.ts
@@ -1,32 +1,16 @@
 import { beforeAll, afterAll, describe, it, expect } from 'vitest';
-import { createServer } from 'http';
 import { AddressInfo } from 'net';
-import { RestTransportAdapter } from '../../src/interfaces/rest/transport';
+import type { Server } from 'http';
 
-let server: ReturnType<typeof createServer>;
+let server: Server;
 let baseUrl: string;
 
-beforeAll(() => {
-  server = createServer((req, res) => {
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk;
-    });
-    req.on('end', () => {
-      res.setHeader('Content-Type', 'application/json');
-      if (req.url === '/hello' && req.method === 'GET') {
-        res.writeHead(200);
-        res.end(JSON.stringify({ hello: 'world' }));
-      } else if (req.url === '/echo' && req.method === 'POST') {
-        const parsed = body ? JSON.parse(body) : {};
-        res.writeHead(200);
-        res.end(JSON.stringify({ received: parsed }));
-      } else {
-        res.writeHead(404);
-        res.end(JSON.stringify({ error: 'not found' }));
-      }
-    });
-  }).listen(0);
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.PORT = '0';
+  const { startServer } = await import('../../src/interfaces/rest/transport');
+  server = startServer();
+  await new Promise((resolve) => server.on('listening', resolve));
   const { port } = server.address() as AddressInfo;
   baseUrl = `http://127.0.0.1:${port}`;
 });
@@ -35,22 +19,12 @@ afterAll(() => {
   server.close();
 });
 
-describe('RestTransportAdapter', () => {
-  it('handles GET requests', async () => {
-    const client = new RestTransportAdapter(baseUrl);
-    const res = await client.get<{ hello: string }>('/hello');
-    expect(res).toEqual({ hello: 'world' });
-  });
-
-  it('handles POST requests with body', async () => {
-    const client = new RestTransportAdapter(baseUrl);
-    const payload = { foo: 'bar' };
-    const res = await client.post<{ received: typeof payload }>('/echo', payload);
-    expect(res).toEqual({ received: payload });
-  });
-
-  it('throws on HTTP errors', async () => {
-    const client = new RestTransportAdapter(baseUrl);
-    await expect(client.get('/missing')).rejects.toThrow(/404/);
+describe('REST server', () => {
+  it('responds to /health', async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok' });
   });
 });
+


### PR DESCRIPTION
## Summary
- replace Axios-based REST client with Express server
- expose startServer that registers routes and listens on runtime-configured port
- add integration test for Express server health route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890bc919fb4832e9798301829acf928