### PR TITLE
docs: explain rest server env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,11 @@ API_KEY=
 # Database connection string
 DATABASE_URL=
 
-# Port for the application to listen on
+# Port for the REST server to listen on.
+# Defaults to 3000.
 PORT=3000
 
-# Node environment
+# Node.js runtime environment (development, production, test).
+# Controls logging and other environment-specific behavior.
 NODE_ENV=development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ npm install
 ```
 
 ### Environment Variables
-Configuration is handled through environment variables stored in an `.env` file at the project root. A typical configuration might look like:
+Configuration is handled through environment variables stored in an `.env` file at the project root.
+
+The REST server honors the following variables:
+
+- `PORT` – Sets the TCP port the Express server listens on. Defaults to `3000`.
+- `NODE_ENV` – Specifies the runtime environment (`development`, `production`, or `test`) and toggles environment-specific behavior such as logging verbosity.
+
+All REST routes are mounted at the root path (`/`).
+
+A typical configuration might look like:
 
 ```
 # .env


### PR DESCRIPTION
## Summary
- document how PORT and NODE_ENV configure the REST server
- clarify defaults for PORT and NODE_ENV in `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890bea2c8f8832ea3c5f89a7b193d94