### PR TITLE
Add E2E test scaffolding for Discord guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Run the test suite with:
 npm test
 ```
 
+#### E2E Tests
+
+End-to-end tests connect to a staging Discord guild. Before running them, set the following environment variables:
+
+- `BOT_TOKEN` – Discord bot token used for authentication.
+- `STAGING_GUILD_ID` – ID of the staging guild used for testing.
+
+If these variables are absent, the E2E tests are skipped.
+
 ## Architecture Overview
 
 ```

--- a/tests/e2e/bot.e2e.test.ts
+++ b/tests/e2e/bot.e2e.test.ts
@@ -1,0 +1,25 @@
+import { Client, GatewayIntentBits } from 'discord.js';
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+
+const token = process.env.BOT_TOKEN;
+const guildId = process.env.STAGING_GUILD_ID;
+
+const skip = !token || !guildId;
+
+(skip ? describe.skip : describe)('bot connection', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({ intents: [GatewayIntentBits.Guilds] });
+    await client.login(token!);
+  });
+
+  afterAll(async () => {
+    await client.destroy();
+  });
+
+  it('connects to staging guild', async () => {
+    const guild = await client.guilds.fetch(guildId!);
+    expect(guild).toBeDefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [
+      'tests/*.test.ts',
+      'tests/unit/**/*.test.ts',
+      'tests/integration/**/*.test.ts',
+      'tests/e2e/**/*.test.ts'
+    ]
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest config covering unit, integration, and new e2e tests
- document Discord bot token and guild ID env vars
- scaffold Discord guild connectivity test that skips when env vars missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c0bbb040832ea98185ed48a90c49