### PR TITLE
Add automation script examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ If these variables are absent, the E2E tests are skipped.
 - **Data Layer** – Database adapters and persistence models.
 - **Utilities** – Shared helpers, configuration loaders, and logging.
 
+
+## Automation Examples
+
+Example scripts for BullMQ and Photoshop ExtendScript are located in the `automation` directory. See the READMEs in `automation/jobs` and `automation/jsx` for setup and usage instructions.

--- a/automation/jobs/README.md
+++ b/automation/jobs/README.md
@@ -1,3 +1,24 @@
 # Automation Jobs
 
-Placeholder for offline job definitions.
+Examples demonstrating BullMQ job producers and consumers.
+
+## Prerequisites
+
+- Node.js dependencies installed (`npm install`)
+- A running Redis server. Start one with `npx redis-server` or `docker run -p 6379:6379 redis`.
+
+## Running the Example
+
+Start a worker to process jobs:
+
+```bash
+npx ts-node automation/jobs/consumer.ts
+```
+
+In another terminal, enqueue a job:
+
+```bash
+npx ts-node automation/jobs/producer.ts
+```
+
+The worker logs job details when it processes a task.

--- a/automation/jobs/consumer.ts
+++ b/automation/jobs/consumer.ts
@@ -1,0 +1,13 @@
+import { Worker } from 'bullmq';
+
+const worker = new Worker('example', async job => {
+  console.log('processing job', job.name, job.data);
+});
+
+worker.on('completed', job => {
+  console.log(`job ${job.id} completed`);
+});
+
+worker.on('failed', (job, err) => {
+  console.error(`job ${job?.id} failed:`, err);
+});

--- a/automation/jobs/producer.ts
+++ b/automation/jobs/producer.ts
@@ -1,0 +1,13 @@
+import { Queue } from 'bullmq';
+
+const queue = new Queue('example');
+
+async function run() {
+  await queue.add('example-job', { message: 'hello from producer' });
+  await queue.close();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/automation/jsx/README.md
+++ b/automation/jsx/README.md
@@ -1,3 +1,15 @@
 # JSX Automation
 
-Placeholder for JSX-based automation helpers.
+Example Photoshop ExtendScript helpers.
+
+## Prerequisites
+
+- Adobe Photoshop with ExtendScript support.
+
+## Running a Script
+
+1. Open Photoshop.
+2. Choose `File > Scripts > Browse...`.
+3. Select one of the `.jsx` files in this directory, such as `hello-world.jsx`.
+
+Photoshop executes the script immediately. You can copy these files into Photoshop's `Presets/Scripts` folder to make them appear directly under the `File > Scripts` menu.

--- a/automation/jsx/hello-world.jsx
+++ b/automation/jsx/hello-world.jsx
@@ -1,0 +1,5 @@
+/**
+ * Simple ExtendScript example for Photoshop.
+ * Displays a greeting dialog.
+ */
+alert('Hello, Photoshop!');

--- a/automation/jsx/list-layers.jsx
+++ b/automation/jsx/list-layers.jsx
@@ -1,0 +1,13 @@
+/**
+ * Lists the names of layers in the active Photoshop document.
+ */
+if (app.documents.length > 0) {
+  var doc = app.activeDocument;
+  var names = [];
+  for (var i = 0; i < doc.layers.length; i++) {
+    names.push(doc.layers[i].name);
+  }
+  alert('Layers: ' + names.join(', '));
+} else {
+  alert('No document open');
+}


### PR DESCRIPTION
## Summary
- add BullMQ producer and consumer examples
- add Photoshop ExtendScript placeholder scripts
- document how to run automation scripts

## Testing
- `npm test` *(fails: spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6890c2bb5750832e9f93de4ee7f7a9b5