### PR TITLE
feat: add discord bot entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "aegir-prime",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/core/index.js",
+  "main": "dist/bot/index.js",
   "scripts": {
     "dev": "ts-node src/core/index.ts",
     "build": "tsc",
-    "start": "npm run build && node .",
+    "start": "npm run build && node dist/bot/index.js",
     "test": "npm run build && vitest run"
   },
   "keywords": [],

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,0 +1,19 @@
+import { discordConfig } from '../config/discord';
+import { DiscordTransportAdapter } from '../interfaces/discord/transport';
+import { logger } from '../core/logger';
+
+async function main(): Promise<void> {
+  const adapter = new DiscordTransportAdapter();
+  await adapter.init(discordConfig.token);
+
+  adapter.useEventGateway({
+    onReady: (client) => {
+      logger.info(`Logged in as ${client.user?.tag ?? 'unknown'}`);
+    },
+  });
+}
+
+main().catch((err) => {
+  logger.error(err, 'Failed to start bot');
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Discord bot entrypoint using DiscordTransportAdapter
- run bot entrypoint in start script

## Testing
- `npm test` *(fails: Missing environment variable DISCORD_TOKEN; spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68922b4ef65c832e8a8281ee178cd7a1