### PR TITLE
feat: add discord bot entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "aegir-prime",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/core/index.js",
+  "main": "dist/bot/index.js",
   "scripts": {
     "dev": "ts-node src/core/index.ts",
     "build": "tsc",
-    "start": "npm run build && node .",
+    "start": "npm run build && node dist/bot/index.js",
     "test": "npm run build && vitest run"
   },
   "keywords": [],

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,0 +1,19 @@
+import { discordConfig } from '../config/discord';
+import { DiscordTransportAdapter } from '../interfaces/discord/transport';
+import { logger } from '../core/logger';
+
+async function main(): Promise<void> {
+  const adapter = new DiscordTransportAdapter();
+  await adapter.init(discordConfig.token);
+
+  adapter.useEventGateway({
+    onReady: (client) => {
+      logger.info(`Logged in as ${client.user?.tag ?? 'unknown'}`);
+    },
+  });
+}
+
+main().catch((err) => {
+  logger.error(err, 'Failed to start bot');
+  process.exit(1);
+});

--- a/src/config/discord.ts
+++ b/src/config/discord.ts
@@ -2,8 +2,8 @@ import { env } from 'process';
 
 export interface DiscordConfig {
   token: string;
-  clientId: string;
-  guildId: string;
+  clientId?: string;
+  guildId?: string;
 }
 
 function requireEnv(key: string): string {
@@ -14,10 +14,14 @@ function requireEnv(key: string): string {
   return value;
 }
 
+function getEnv(key: string): string | undefined {
+  return env[key];
+}
+
 const config: DiscordConfig = {
   token: requireEnv('DISCORD_TOKEN'),
-  clientId: requireEnv('DISCORD_CLIENT_ID'),
-  guildId: requireEnv('DISCORD_GUILD_ID')
+  clientId: getEnv('DISCORD_CLIENT_ID'),
+  guildId: getEnv('DISCORD_GUILD_ID'),
 };
 
 export const discordConfig: Readonly<DiscordConfig> = Object.freeze(config);


### PR DESCRIPTION
## Summary
- add Discord bot entrypoint using DiscordTransportAdapter
- run bot entrypoint in start script
- allow Discord client and guild IDs to be optional

## Testing
- `npm test` *(fails: hook timed out; Missing environment variable DISCORD_TOKEN; spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68922b4ef65c832e8a8281ee178cd7a1