### PR TITLE
feat(discord): add ping command

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,14 +1,35 @@
 import { discordConfig } from '../config/discord';
 import { DiscordTransportAdapter } from '../interfaces/discord/transport';
 import { logger } from '../core/logger';
+import * as Ping from '../interfaces/discord/commands/ping';
 
 async function main(): Promise<void> {
-  const adapter = new DiscordTransportAdapter();
-  await adapter.init(discordConfig.token);
+  const discord = new DiscordTransportAdapter();
+  await discord.init(discordConfig.token);
 
-  adapter.useEventGateway({
-    onReady: (client) => {
+  const commands = { ping: Ping } as const;
+
+  discord.useEventGateway({
+    onReady: async (client) => {
       logger.info(`Logged in as ${client.user?.tag ?? 'unknown'}`);
+
+      const guildId = discordConfig.guildId;
+      if (guildId) {
+        await discord.registerGuildCommands(guildId, [Ping.data]);
+        logger.info('Registered guild commands');
+      }
+    },
+    onInteraction: async (interaction) => {
+      if (!interaction.isChatInputCommand()) {
+        return;
+      }
+
+      const command = commands[interaction.commandName as keyof typeof commands];
+      if (!command) {
+        return;
+      }
+
+      await command.execute(interaction);
     },
   });
 }

--- a/src/interfaces/discord/commands/ping.ts
+++ b/src/interfaces/discord/commands/ping.ts
@@ -1,0 +1,14 @@
+import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
+
+export const data = new SlashCommandBuilder()
+  .setName('ping')
+  .setDescription('Health check');
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await interaction.reply({
+    content: `pong ${process.uptime()}`,
+    ephemeral: true,
+  });
+}


### PR DESCRIPTION
## Summary
- add ping slash command for health checks
- register ping command on startup and handle interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3766f5a5c832eb7c37f64d5745fda