### PR TITLE
chore: add prestart script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "ts-node src/core/index.ts",
     "build": "tsc",
     "start": "npm run build && node dist/bot/index.js",
+    "prestart": "prisma generate && prisma migrate deploy && npm run db:seed --if-present",
     "test": "npm run build && vitest run"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- run database setup before starting the app

## Testing
- `npm test` *(fails: Missing environment variable: DISCORD_TOKEN; redis-server not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a379877bd4832e8e90019a87f2b172