### PR TITLE
fix(prisma): switch datasource to postgresql and push schema on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "ts-node src/core/index.ts",
     "build": "tsc",
     "start": "npm run build && node dist/bot/index.js",
-    "prestart": "prisma generate && prisma migrate deploy && npm run db:seed --if-present",
+    "prestart": "prisma generate && prisma db push && npm run db:seed --if-present",
     "db:seed": "prisma db seed",
     "test": "npm run build && vitest run"
   },

--- a/prisma/migration_lock.toml
+++ b/prisma/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,9 +6,9 @@ generator client {
   provider = "prisma-client-js"
 }
 
-// SQLite datasource (update DATABASE_URL if needed)
+// Postgres datasource (update DATABASE_URL if needed)
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- switch Prisma datasource to PostgreSQL
- add migration lock for PostgreSQL
- push schema and seed database during startup

## Testing
- `npm test` *(fails: Cannot find module 'process' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a463242128832eb76a8e73b87f5ed8