### PR TITLE
chore(runtime): use Node 20 and fix prisma seed to --import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/bot/index.js",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.6.0"
   },
   "scripts": {
     "dev": "ts-node src/core/index.ts",
@@ -15,7 +15,7 @@
     "test": "npm run build && vitest run"
   },
   "prisma": {
-    "seed": "tsx prisma/seed.ts"
+    "seed": "node --import tsx prisma/seed.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- use Node.js 20 in engines
- use `node --import tsx` for prisma seed

## Testing
- `npm test` *(fails: Missing environment variable: DISCORD_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68a46ad9af34832e967e5b3d5c0726f4