### PR TITLE
chore(ping): use flags for ephemeral replies

### DIFF
--- a/src/interfaces/discord/commands/ping.ts
+++ b/src/interfaces/discord/commands/ping.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, type ChatInputCommandInteraction } from 'discord.js';
+import { SlashCommandBuilder, MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
 
 export const data = new SlashCommandBuilder()
   .setName('ping')
@@ -9,6 +9,6 @@ export async function execute(
 ): Promise<void> {
   await interaction.reply({
     content: `pong ${process.uptime()}`,
-    ephemeral: true,
+    flags: MessageFlags.Ephemeral,
   });
 }


### PR DESCRIPTION
## Summary
- use MessageFlags.Ephemeral for ping command replies

## Testing
- `npm test` *(fails: Missing environment variable: DISCORD_TOKEN; spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a4937404c0832e9c84f3e49a4d9884