### PR TITLE
feat(prisma): add Player/Item/Inventory schema and seed base catalog (JS)

### DIFF
--- a/prisma/migrations/000_init.sql
+++ b/prisma/migrations/000_init.sql
@@ -1,22 +1,32 @@
 -- Baseline migration for initial models
 
-CREATE TABLE "Character" (
+CREATE TYPE "ItemCategory" AS ENUM ('RESOURCE', 'SHIP', 'GENERAL');
+
+CREATE TABLE "Player" (
   "id" TEXT PRIMARY KEY NOT NULL,
-  "name" TEXT NOT NULL
+  "discordId" TEXT NOT NULL UNIQUE,
+  "name" TEXT NOT NULL,
+  "bio" TEXT,
+  "gold" INTEGER NOT NULL DEFAULT 100000,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE "Wallet" (
+CREATE TABLE "Item" (
   "id" TEXT PRIMARY KEY NOT NULL,
-  "balance" INTEGER NOT NULL
+  "key" TEXT NOT NULL UNIQUE,
+  "name" TEXT NOT NULL,
+  "category" "ItemCategory" NOT NULL,
+  "stackable" BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-CREATE TABLE "Listing" (
+CREATE TABLE "Inventory" (
   "id" TEXT PRIMARY KEY NOT NULL,
-  "title" TEXT NOT NULL,
-  "price" INTEGER NOT NULL
+  "playerId" TEXT NOT NULL,
+  "itemId" TEXT NOT NULL,
+  "quantity" INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "Inventory_playerId_itemId_key" UNIQUE ("playerId", "itemId"),
+  CONSTRAINT "Inventory_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "Inventory_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE RESTRICT ON UPDATE CASCADE
 );
 
-CREATE TABLE "Technology" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "name" TEXT NOT NULL
-);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,23 +12,39 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Character {
-  id   String @id @default(uuid())
-  name String
+enum ItemCategory {
+  RESOURCE
+  SHIP
+  GENERAL
 }
 
-model Wallet {
-  id      String @id @default(uuid())
-  balance Int
+model Player {
+  id        String   @id @default(cuid())
+  discordId String   @unique
+  name      String
+  bio       String?
+  gold      Int      @default(100000)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
-model Listing {
-  id    String @id @default(uuid())
-  title String
-  price Int
+model Item {
+  id        String       @id @default(cuid())
+  key       String       @unique
+  name      String
+  category  ItemCategory
+  stackable Boolean      @default(true)
+  inventories Inventory[]
 }
 
-model Technology {
-  id   String @id @default(uuid())
-  name String
+model Inventory {
+  id        String @id @default(cuid())
+  playerId  String
+  itemId    String
+  quantity  Int    @default(0)
+  player    Player @relation(fields: [playerId], references: [id])
+  item      Item   @relation(fields: [itemId], references: [id])
+
+  @@unique([playerId, itemId])
 }
+

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -1,10 +1,31 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, ItemCategory } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
+const items = [
+  { key: 'afm', name: 'Alloy Frame Modules', category: ItemCategory.RESOURCE },
+  { key: 'pcc', name: 'Plasma Core Cells', category: ItemCategory.RESOURCE },
+  { key: 'oop', name: 'Oblivion Ore Plates', category: ItemCategory.RESOURCE },
+  { key: 'ggp', name: 'Graveglass Panels', category: ItemCategory.RESOURCE },
+  { key: 'qfr', name: 'Quantum Flux Regulators', category: ItemCategory.RESOURCE },
+  { key: 'ncm', name: 'Neural Command Matrices', category: ItemCategory.RESOURCE },
+  { key: 'corvette', name: 'Corvette', category: ItemCategory.SHIP, stackable: false },
+  { key: 'destroyer', name: 'Destroyer', category: ItemCategory.SHIP, stackable: false },
+  { key: 'heavy_frigate', name: 'Heavy Frigate', category: ItemCategory.SHIP, stackable: false },
+  { key: 'cruiser', name: 'Cruiser', category: ItemCategory.SHIP, stackable: false }
+];
+
 try {
-  await prisma.$connect();
-  console.log('Seed: no-op (placeholder)');
+  for (const data of items) {
+    await prisma.item.upsert({
+      where: { key: data.key },
+      update: {},
+      create: data
+    });
+  }
+} catch (e) {
+  console.error(e);
+  process.exit(1);
 } finally {
   await prisma.$disconnect();
 }


### PR DESCRIPTION
## Summary
- add Player, Item, and Inventory models with ItemCategory enum
- seed initial resource and ship items via idempotent JS script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a497b80bd0832e82948b54f2651900