### PR TITLE
fix(prisma): add inventories relation on Player model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Player {
   gold      Int      @default(100000)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  inventories Inventory[]
 }
 
 model Item {


### PR DESCRIPTION
## Summary
- add inventories relation on Player model

## Testing
- `npm test` *(fails: Missing environment variable: DISCORD_TOKEN, spawn redis-server ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b981dad4832ea4c7c7a774c1fea6